### PR TITLE
Refactor to allow more generic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ssh-tunnel salt formula
 
-This formula can set up SSH tunnels for users.
+This formula creates users with limited access where only ssh tunnels can be created.
+If users are already present, they will be restricted as well.
 
 See `pillar.example` for more information.

--- a/init.sls
+++ b/init.sls
@@ -1,4 +1,4 @@
-{% for username, data in pillar['ssh-tunnel']['users']|dictsort %}
+{% for username, data in pillar['ssh-tunnels']|dictsort %}
 
 {{ username }}:
   user.present:

--- a/init.sls
+++ b/init.sls
@@ -2,7 +2,7 @@
 
 {{ username }}:
   user.present:
-    - fullname: {{ data['name'] }}
+    - fullname: {{ data['fullname'] }}
     - shell: /bin/bash
     - home: /home/{{ username }}
 

--- a/init.sls
+++ b/init.sls
@@ -1,4 +1,4 @@
-{% for username, data in pillar['ssh-tunnels']|dictsort %}
+{% for username, data in pillar['ssh-tunnel']|dictsort %}
 
 {{ username }}:
   user.present:

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,6 @@
 # vim: ft=sls
 
-ssh-tunnels:
+ssh-tunnel:
   adam.jensen:
     fullname: Adam Jensen
     allowed_hosts:

--- a/pillar.example
+++ b/pillar.example
@@ -1,18 +1,10 @@
 # vim: ft=sls
 
-common-hosts:
- - &nginx
-   localhost:443
-
-ssh-tunnel:
-  users:
+ssh-tunnels:
     adam.jensen:
       fullname: Adam Jensen
-      # allowed_hosts can use yaml anchors to reuse configuration
-      # in this example, it uses both a common host + individually
-      # defined 8080 port.
       allowed_hosts:
-        - *nginx
+        - localhost:443
         - localhost:8080
       pubkeys:
         - ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>

--- a/pillar.example
+++ b/pillar.example
@@ -1,9 +1,18 @@
 # vim: ft=sls
+
+common-hosts:
+ - &nginx
+   localhost:443
+
 ssh-tunnel:
-  remote-hosts:
-    - example1.com:443
-    - example2.com:443
   users:
     adam.jensen:
       name: Adam Jensen
-      pubkey: ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>
+      # allowed_hosts can use yaml anchors to reuse configuration
+      # in this example, it uses both a common host + individually
+      # defined 8080 port.
+      allowed_hosts:
+        - *nginx
+        - localhost:8080
+      pubkeys:
+        - ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>

--- a/pillar.example
+++ b/pillar.example
@@ -7,7 +7,7 @@ common-hosts:
 ssh-tunnel:
   users:
     adam.jensen:
-      name: Adam Jensen
+      fullname: Adam Jensen
       # allowed_hosts can use yaml anchors to reuse configuration
       # in this example, it uses both a common host + individually
       # defined 8080 port.

--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,10 @@
 # vim: ft=sls
 
 ssh-tunnels:
-    adam.jensen:
-      fullname: Adam Jensen
-      allowed_hosts:
-        - localhost:443
-        - localhost:8080
-      pubkeys:
-        - ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>
+  adam.jensen:
+    fullname: Adam Jensen
+    allowed_hosts:
+      - localhost:443
+      - localhost:8080
+    pubkeys:
+      - ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>


### PR DESCRIPTION
This allows:

- A few combinations of the ways in which hosts can be allowed (thanks to yaml!), like following and as I have indicated in the `pillar.example`:

```
allowed_hosts: &allowed_hosts
  - localhost:2222
  - localhost:2223
  - localhost:2224
  
  ssh-tunnel:
  users:
    foo:
      name: Foo
      allowed_hosts: *allowed_hosts
```

- multiple public keys