### PR TITLE
Add formula for only allowing instances registered with salt-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,14 @@
 This formula creates users with limited access where only ssh tunnels can be created.
 If users are already present, they will be restricted as well.
 
-See `pillar.example` for more information.
+
+# Formulas
+
+## ssh-tunnel
+
+Deploys SSH users according to pillar configuration, see `pillar.example` for details.
+
+
+## ssh-tunnel.ssh-salt-only
+
+Deploys SSH users allowing to connect to port `22` of all hosts registered with `salt-master`.

--- a/pillar.example
+++ b/pillar.example
@@ -3,8 +3,11 @@
 ssh-tunnel:
   adam.jensen:
     fullname: Adam Jensen
+
+    # NOTE: This will be skipped when ssh-tunnel.only-salt is used
     allowed_hosts:
       - localhost:443
       - localhost:8080
+
     pubkeys:
       - ssh-ed25519 AAAAC.... Adam Jensen <adam@deusex.universe>

--- a/salt-only.sls
+++ b/salt-only.sls
@@ -1,0 +1,32 @@
+{% set minion_data = salt['mine.get']('*', 'grains.item') %}
+
+{% for username, data in pillar['ssh-tunnel']|dictsort %}
+
+{{ username }}:
+  user.present:
+    - fullname: {{ data['fullname'] }}
+    - shell: /bin/bash
+    - home: /home/{{ username }}
+
+/home/{{ username }}/.ssh:
+  file.directory:
+    - user: {{ username }}
+    - group: {{ username }}
+    - mode: 755
+    - require:
+      - user: {{ username }}
+
+/home/{{ username }}/.ssh/authorized_keys:
+  file.managed:
+    - user: {{ username }}
+    - group: {{ username }}
+    - mode: 644
+    - contents:
+      # Allow SSH tunneling only to hosts registered with salt-master
+      {% for pubkey in data['pubkeys'] %}
+      - no-pty,no-user-rc,no-agent-forwarding,no-X11-forwarding,{% for host, data in minion_data.items() %}permitopen="{{ data['fqdn'] }}:22",{% endfor %}command="/bin/echo do-not-send-commands" {{ pubkey }}
+      {% endfor %}
+    - require:
+      - user: {{ username }}
+
+{% endfor %}


### PR DESCRIPTION
This hardcodes port `22` currently, as I didn't want to introduce another pillar that's only used with this formula. Could be improved I think. 